### PR TITLE
return value was removing the wrong functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,8 +47,8 @@ module.exports = function post (db, opts, each) {
 
   return function () {
     db.removeListener('put', onPut)
-    db.removeListener('del', onPut)
-    db.removeListener('batch', onPut)
+    db.removeListener('del', onDel)
+    db.removeListener('batch', onBatch)
   }
 }
 


### PR DESCRIPTION
I was noticing that scuttlebot was slowing down a lot on my machine so I had to kill it quite often. Adding a debugger I could see that it was stuck in 50k onBatch calls. The problem seems to be that this:

https://github.com/ssbc/secure-scuttlebutt/blob/master/indexes/clock.js

read() calls:

https://github.com/pull-stream/pull-level/blob/master/live.js

Which in turn sets up a ton of event handlers but none of them gets removed because the return function removes the wrong function.

Seems like a copy/paste bug ;-)